### PR TITLE
Lock dependency version for progressbar

### DIFF
--- a/ppbench/lib/ppbench/version.rb
+++ b/ppbench/lib/ppbench/version.rb
@@ -1,3 +1,3 @@
 module Ppbench
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/ppbench/ppbench.gemspec
+++ b/ppbench/ppbench.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_runtime_dependency "commander"
   spec.add_runtime_dependency "parallel"
-  spec.add_runtime_dependency "progressbar"
+  spec.add_runtime_dependency "progressbar", "~> 0.21"
   spec.add_runtime_dependency "descriptive_statistics"
   spec.add_runtime_dependency "terminal-table"
   spec.add_runtime_dependency "httpclient"


### PR DESCRIPTION
The progressbar gem recently released a new version
where they unified with ruby-progressbar. This changed
the API a lot and it is no longer compatible with ppbench.

This change locks down to the old version of progressbar.

