### PR TITLE
Made Go code more clean

### DIFF
--- a/pingpong-go/src/pingpong/ping/Ping.go
+++ b/pingpong-go/src/pingpong/ping/Ping.go
@@ -65,6 +65,8 @@ func mpingHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(json))
 }
 
+// Start starts the ping service on the given port. ponghost and pongport are the
+// connection details of the pong service.
 func Start(port int, ponghost string, pongport int) {
 	myport := fmt.Sprintf(":%v", port)
 

--- a/pingpong-go/src/pingpong/ping/Ping.go
+++ b/pingpong-go/src/pingpong/ping/Ping.go
@@ -1,11 +1,12 @@
-package ping 
+package ping
 
 import (
-    "net/http"
-    "io/ioutil"
-    "fmt"
-    "github.com/gorilla/mux"
-    "time"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
 )
 
 const RETRIES = 100
@@ -14,28 +15,32 @@ const JSONANSWER = "{\"length\": %v, \"code\": %v, \"retries\": %v, \"duration\"
 var pongUrl string
 
 func get(url string) (content string, code int, err error) {
-	res, err     := http.Get(url)
-	if (err != nil) { return "", http.StatusServiceUnavailable, err }
-	
-	message, err := ioutil.ReadAll(res.Body)	
-	if (err != nil) { return "", http.StatusServiceUnavailable, err }
-	
+	res, err := http.Get(url)
+	if err != nil {
+		return "", http.StatusServiceUnavailable, err
+	}
+
+	message, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", http.StatusServiceUnavailable, err
+	}
+
 	return string(message), res.StatusCode, err
 }
 
 func pingHandler(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	
+
 	for i := 1; i <= RETRIES; i++ {
 		message, _, err := get(pongUrl + "/pong/" + params["length"])
-		
+
 		if err == nil {
 			fmt.Fprintf(w, message)
 			return
-		}		
+		}
 	}
 
-	w.WriteHeader(http.StatusServiceUnavailable);
+	w.WriteHeader(http.StatusServiceUnavailable)
 	w.Write([]byte("Service unavailable"))
 }
 
@@ -44,10 +49,10 @@ func mpingHandler(w http.ResponseWriter, r *http.Request) {
 
 	start := time.Now().UnixNano()
 	for retries := 0; retries < RETRIES; retries++ {
-		message, code, err   := get(pongUrl + "/pong/" + params["length"])
+		message, code, err := get(pongUrl + "/pong/" + params["length"])
 		if err == nil {
 			end := time.Now().UnixNano()
-			duration := float64(end - start) / 1000.0 / 1000.0
+			duration := float64(end-start) / 1000.0 / 1000.0
 			json := fmt.Sprintf(JSONANSWER, len(message), code, retries, duration)
 			w.Write([]byte(json))
 			return
@@ -55,21 +60,21 @@ func mpingHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	end := time.Now().UnixNano()
-	duration := float64(end - start) / 1000.0 / 1000.0
+	duration := float64(end-start) / 1000.0 / 1000.0
 	json := fmt.Sprintf(JSONANSWER, 0, http.StatusServiceUnavailable, RETRIES, duration)
 	w.Write([]byte(json))
 }
 
 func Start(port int, ponghost string, pongport int) {
-    myport := fmt.Sprintf(":%v", port)
-    
-    pongUrl = fmt.Sprintf("http://%s:%v",  ponghost, pongport)
-    
-    r := mux.NewRouter()
-    r.HandleFunc("/ping/{length:[0-9]+}", pingHandler)
-    r.HandleFunc("/mping/{length:[0-9]+}", mpingHandler)
-        
+	myport := fmt.Sprintf(":%v", port)
+
+	pongUrl = fmt.Sprintf("http://%s:%v", ponghost, pongport)
+
+	r := mux.NewRouter()
+	r.HandleFunc("/ping/{length:[0-9]+}", pingHandler)
+	r.HandleFunc("/mping/{length:[0-9]+}", mpingHandler)
+
 	fmt.Printf("Ping service is up and listening on port %v\n", port)
-    fmt.Printf("Pong service assumed to be reachable at %s\n", pongUrl)
-    http.ListenAndServe(myport, r)   
+	fmt.Printf("Pong service assumed to be reachable at %s\n", pongUrl)
+	http.ListenAndServe(myport, r)
 }

--- a/pingpong-go/src/pingpong/ping/Ping.go
+++ b/pingpong-go/src/pingpong/ping/Ping.go
@@ -9,8 +9,8 @@ import (
 	"github.com/gorilla/mux"
 )
 
-const RETRIES = 100
-const JSONANSWER = "{\"length\": %v, \"code\": %v, \"retries\": %v, \"duration\": %v}"
+const retries = 100
+const jsonAnswer = "{\"length\": %v, \"code\": %v, \"retries\": %v, \"duration\": %v}"
 
 var pongUrl string
 
@@ -31,7 +31,7 @@ func get(url string) (content string, code int, err error) {
 func pingHandler(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 
-	for i := 1; i <= RETRIES; i++ {
+	for i := 1; i <= retries; i++ {
 		message, _, err := get(pongUrl + "/pong/" + params["length"])
 
 		if err == nil {
@@ -48,12 +48,12 @@ func mpingHandler(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 
 	start := time.Now().UnixNano()
-	for retries := 0; retries < RETRIES; retries++ {
+	for r := 0; r < retries; r++ {
 		message, code, err := get(pongUrl + "/pong/" + params["length"])
 		if err == nil {
 			end := time.Now().UnixNano()
 			duration := float64(end-start) / 1000.0 / 1000.0
-			json := fmt.Sprintf(JSONANSWER, len(message), code, retries, duration)
+			json := fmt.Sprintf(jsonAnswer, len(message), code, r, duration)
 			w.Write([]byte(json))
 			return
 		}
@@ -61,7 +61,7 @@ func mpingHandler(w http.ResponseWriter, r *http.Request) {
 
 	end := time.Now().UnixNano()
 	duration := float64(end-start) / 1000.0 / 1000.0
-	json := fmt.Sprintf(JSONANSWER, 0, http.StatusServiceUnavailable, RETRIES, duration)
+	json := fmt.Sprintf(jsonAnswer, 0, http.StatusServiceUnavailable, retries, duration)
 	w.Write([]byte(json))
 }
 

--- a/pingpong-go/src/pingpong/pingpong.go
+++ b/pingpong-go/src/pingpong/pingpong.go
@@ -1,11 +1,12 @@
-package main 
+package main
 
 import (
-	"fmt"
 	"flag"
-	"pingpong/pong"
-	"pingpong/ping"
+	"fmt"
 	"os"
+
+	"pingpong/ping"
+	"pingpong/pong"
 )
 
 func main() {
@@ -15,23 +16,22 @@ func main() {
 	ponghost := flag.String("pongHost", "localhost", "Host (valid DNS name or IP) of the pong service")
 	pongport := flag.Int("pongPort", 8080, "Port of the pong service")
 	flag.Parse()
-	
-	if (*aspong && *asping) {
+
+	if *aspong && *asping {
 		fmt.Println("You can only start ping or pong service, not both with the same command.")
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
-	
-	if (*aspong) { 
-		pong.Start(*port) 
+
+	if *aspong {
+		pong.Start(*port)
 		os.Exit(0)
 	}
-	
-	if (*asping) { 
-		ping.Start(*port, *ponghost, *pongport) 
+
+	if *asping {
+		ping.Start(*port, *ponghost, *pongport)
 		os.Exit(0)
 	}
-	
+
 	flag.PrintDefaults()
 }
-

--- a/pingpong-go/src/pingpong/pong/Pong.go
+++ b/pingpong-go/src/pingpong/pong/Pong.go
@@ -11,11 +11,13 @@ import (
 
 func pongHandler(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	i, _ := strconv.Atoi(params["length"])
+	i, err := strconv.Atoi(params["length"])
+	if err != nil {
+		panic(err)
+	}
 	i -= 4
-	var result bytes.Buffer
-	result.WriteString("po")
-	for ; i > 0; i-- {
+	result := bytes.NewBufferString("po")
+	for j := 0; j < i; j++ {
 		result.WriteString("o")
 	}
 	result.WriteString("ng")

--- a/pingpong-go/src/pingpong/pong/Pong.go
+++ b/pingpong-go/src/pingpong/pong/Pong.go
@@ -1,11 +1,12 @@
-package pong 
+package pong
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
-	"github.com/gorilla/mux"
 	"strconv"
-	"bytes"
+    
+    "github.com/gorilla/mux"
 )
 
 func pongHandler(w http.ResponseWriter, r *http.Request) {
@@ -14,16 +15,18 @@ func pongHandler(w http.ResponseWriter, r *http.Request) {
 	i -= 4
 	var result bytes.Buffer
 	result.WriteString("po")
-	for ; i > 0; i-- { result.WriteString("o") }
+	for ; i > 0; i-- {
+		result.WriteString("o")
+	}
 	result.WriteString("ng")
 	w.Write(result.Bytes())
 }
 
 func Start(port int) {
 	r := mux.NewRouter()
-    r.HandleFunc("/pong/{length:[0-9]+}", pongHandler)
-    sport := fmt.Sprintf(":%v", port)
-    
+	r.HandleFunc("/pong/{length:[0-9]+}", pongHandler)
+	sport := fmt.Sprintf(":%v", port)
+
 	fmt.Printf("Pong service is up and listening on port %v", port)
-    http.ListenAndServe(sport, r)
+	http.ListenAndServe(sport, r)
 }

--- a/pingpong-go/src/pingpong/pong/Pong.go
+++ b/pingpong-go/src/pingpong/pong/Pong.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-    
-    "github.com/gorilla/mux"
+
+	"github.com/gorilla/mux"
 )
 
 func pongHandler(w http.ResponseWriter, r *http.Request) {

--- a/pingpong-go/src/pingpong/pong/Pong.go
+++ b/pingpong-go/src/pingpong/pong/Pong.go
@@ -22,6 +22,7 @@ func pongHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(result.Bytes())
 }
 
+// Start starts the pong service on the given port.
 func Start(port int) {
 	r := mux.NewRouter()
 	r.HandleFunc("/pong/{length:[0-9]+}", pongHandler)


### PR DESCRIPTION
Fixed following issues:

pingpong/pingpong-go/src/pingpong/pong/Pong.go
Line 1: warning: file is not gofmted with -s (gofmt)
pingpong/pingpong-go/src/pingpong/pingpong.go
Line 1: warning: file is not gofmted with -s (gofmt)
pingpong/pingpong-go/src/pingpong/ping/Ping.go
Line 1: warning: file is not gofmted with -s (gofmt)

pingpong/pingpong-go/src/pingpong/pong/Pong.go
Line 22: warning: exported function Start should have comment or be unexported (golint)
pingpong/pingpong-go/src/pingpong/ping/Ping.go
Line 11: warning: exported const RETRIES should have comment or be unexported (golint)
Line 12: warning: exported const JSONANSWER should have comment or be unexported (golint)
Line 63: warning: exported function Start should have comment or be unexported (golint)

nkratzke/pingpong:master: https://goreportcard.com/report/github.com/nkratzke/pingpong
amller/pingpong:master: https://goreportcard.com/report/github.com/amller/pingpong

Additionaly I added error handling to pingpong-go/src/pingpong/pong/Pong.go:15